### PR TITLE
Added init argument w/ alias inits to ordbetareg()

### DIFF
--- a/R/modeling.R
+++ b/R/modeling.R
@@ -134,9 +134,14 @@ ordbetareg <- function(formula=NULL,
                        phi_coef_prior_mean=0,
                        phi_coef_prior_sd=5,
                        extra_prior=NULL,
-                       inits="0",
+                       init ="0",
+                       inits = NULL
                        ...) {
-
+  
+  if(!is.null(inits)){
+    init <- inits
+  }
+  
 
   if(is.null(formula)) {
 

--- a/R/modeling.R
+++ b/R/modeling.R
@@ -451,7 +451,7 @@ ordbetareg <- function(formula=NULL,
                    stanvars=ordbeta_mod$stanvars,
                    family=ordbeta_mod$family,
                    prior=ordbeta_mod$priors_phireg,
-                   inits=inits,
+                   init=init,
                    ...)
 
     } else {
@@ -461,7 +461,7 @@ ordbetareg <- function(formula=NULL,
         brm_multiple(formula=formula, data=data,
                      stanvars=ordbeta_mod$stanvars,
                      prior=ordbeta_mod$priors,
-                     inits=inits,
+                     init=init,
                      ...)
 
       } else {
@@ -470,7 +470,7 @@ ordbetareg <- function(formula=NULL,
                      stanvars=ordbeta_mod$stanvars,
                      family=ordbeta_mod$family,
                      prior=ordbeta_mod$priors,
-                     inits=inits,
+                     init=init,
                      ...)
 
 
@@ -490,7 +490,7 @@ ordbetareg <- function(formula=NULL,
           stanvars=ordbeta_mod$stanvars,
           family=ordbeta_mod$family,
           prior=ordbeta_mod$priors_phireg,
-          inits=inits,
+          init=init,
           ...)
 
     } else {
@@ -500,7 +500,7 @@ ordbetareg <- function(formula=NULL,
         brm(formula=formula, data=data,
             stanvars=ordbeta_mod$stanvars,
             prior=ordbeta_mod$priors,
-            inits=inits,
+            init=init,
             ...)
 
 
@@ -510,7 +510,7 @@ ordbetareg <- function(formula=NULL,
             stanvars=ordbeta_mod$stanvars,
             family=ordbeta_mod$family,
             prior=ordbeta_mod$priors,
-            inits=inits,
+            init=init,
             ...)
 
 

--- a/R/modeling.R
+++ b/R/modeling.R
@@ -77,7 +77,7 @@
 #'  regression coefficient, added to the model by passing one of the `brms`
 #'  functions [brms::set_prior] or [brms::prior_string] with appropriate
 #'  values.
-#' @param inits This parameter is used to determine starting values for
+#' @param init This parameter is used to determine starting values for
 #'   the Stan sampler to begin Markov Chain Monte Carlo sampling. It is
 #'   set by default at 0 because the non-linear nature of beta regression
 #'   means that it is possible to begin with extreme values depending on the
@@ -87,6 +87,7 @@
 #'   with an experimental feature of `brms`, set this to `"random"` to get
 #'   more robust starting values (just be sure to scale the covariates so they are
 #'   not too large in absolute size).
+#' @param inits Alias of `init`. Overrides `init` when not NULL.
 #' @param ... All other arguments passed on to the `brm` function
 #' @return A `brms` object fitted with the ordered beta regression distribution.
 #' @examples


### PR DESCRIPTION
This is an updated PR since it's probably cleaner to have just the intended commit(s) and accidentally closed the previous one.

The `brm()` argument `inits` is a deprecated alias of its `init` argument that produces a warning when `ordbetareg()` is called. This is annoying and it's best to avoid deprecated arguments. This pull request aims to fix this, although you'll need to additionally update the documentation accordingly with roxygen or whatever you use for it.

While both the warning and reliance on a deprecated argument are resolvable by passing values from the `ordbetareg()` argument `inits` to the `init` argument of `brms` functions, this would create confusing inconsistency in the names of arguments across `brms` and `ordbetareg`.  Changing the `ordbetareg()` argument from `inits` to `init` also could break previous code fitting models with `ordbetareg()`. This PR aims to not break previous code while eliminating the warning/reliance on deprecated argument `inits` of `brm()`. 

I do this by renaming the `inits` argument for `ordbetareg()` to `init` (preserving its default value of "0") and creating a new argument `inits` that is NULL by default. If `inits` is not NULL (because the user passed it an object), the changes assign those values to `init`. This ensures that previous code passing values to `inits` still works. I then pass the `init` object to the `brm()` `init` argument. This eliminates the error message while ensuring the default/primary argument for initializing values within `ordbetareg()` has the same name as the primary, non-deprecated `brm()` argument.