### PR TITLE
marginaleffects 0.9.0 compatibility

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -30,7 +30,7 @@ Suggests:
     knitr,
     ggplot2,
     modelsummary,
-    marginaleffects,
+    marginaleffects (>= 0.9.0),
     haven,
     stringr,
     Hmisc

--- a/vignettes/package_introduction.Rmd
+++ b/vignettes/package_introduction.Rmd
@@ -201,17 +201,13 @@ modelsummary(ord_fit_mean,statistic = "conf.int",
 There is a related package, `marginaleffects`, that allows us to convert these coefficients into more meaningful marginal effect estimates, i.e., the effect of the predictors expresses as the actual change in the outcome on the 0 - 1 scale. We can't calculate marginal effects for all of the predictors as some of them are cutpoints, etc. (the function will return an error about the intercept), so we'll focus on one of the main effects we are interested in as in the table above:
 
 ```{r marg_effect}
-
 library(marginaleffects)
 
-marg_effs <- marginaleffects(ord_fit_mean,
-                             variables="education")
-
-summary(marg_effs) %>% knitr::kable()
-
+avg_slopes(ord_fit_mean, variables="education") %>%
+  knitr::kable()
 ```
 
-We can see that we have separate marginal effects for each level of education due to modeling it as an ordinal predictor. At present the `marginaleffects` cannot calculate a single effect, though that is possible manually. As we can see with the raw coefficient in the table above, the marginal effects are all positive, though the magnitude varies across different levels of education.
+We can see that we have separate marginal effects for each level of education due to modeling it as an ordinal predictor. At present the `slopes()` function cannot calculate a single effect, though that is possible manually. As we can see with the raw coefficient in the table above, the marginal effects are all positive, though the magnitude varies across different levels of education.
 
 # Understanding Clustering/Polarization of Respondents
 


### PR DESCRIPTION
I am releasing version 0.9.0 of `marginaleffects` right now and got an email from CRAN saying that the new version breaks your vignette.

This is very weird because I have done my best to ensure backward compatibility, your particular use case is very "simple" and should be supported, and I can knit the vignette without any issues with the latest `ordbetareg` and `marginaleffects` on my computer.

In any case, there's a chance you will get an email from CRAN in the near future asking you to fix the vignette. This PR updates the vignette to use the recommended call in versions of `marginaleffects` after 0.9.0.

Sorry for the trouble!