### PR TITLE
modelsummary 1.4.0

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -33,6 +33,7 @@ Imports:
 Suggests: 
     rmarkdown,
     knitr,
+    gt,
     modelsummary,
     marginaleffects (>= 0.9.0),
     haven,

--- a/vignettes/package_introduction.Rmd
+++ b/vignettes/package_introduction.Rmd
@@ -39,6 +39,8 @@ knitr::opts_chunk$set(
 )
 options(rmarkdown.html_vignette.check_title = FALSE)
 
+options(modelsummary_factory_default = "gt")
+
 set.seed(628871)
 
 ```


### PR DESCRIPTION
`kableExtra` does not appear to be actively maintained and it causes some problems on `pkgdown` websites and for installation on some platforms. In version 1.4.0, `modelsummary` will no longer depend on `kableExtra`. Instead it will give the user a choice to install any of the supported table-making package, and offer a function to set a persistent default.

Call setting:

```r
modelsummary(model, output = "gt")
```

Persistent setting stays only for the current session:

```r
options(modelsummary_factory_default = "gt")
```

Persistent setting stays across sessions:

```r
config_modelsummary(factory_default = "gt")
```

Developers of packages that use `modelsummary` in vignettes need to add a table-making package to `Suggests`.

