### PR TITLE
glmmTMB vcov=FALSE

### DIFF
--- a/vignettes/package_introduction.Rmd
+++ b/vignettes/package_introduction.Rmd
@@ -291,7 +291,7 @@ glmm_tmb_fit <- glmmTMB(therm_norm ~ approval + (1|region),
 # model coefficients
 # modelsummary(glmm_tmb_fit)
 # marginal effects in scale of the outcome
-avg_slopes(glmm_tmb_fit)
+avg_slopes(glmm_tmb_fit, vcov = FALSE)
 
 ```
 


### PR DESCRIPTION
I have concerns about the `marginaleffects` (and also base `predict.glmmTMB`) standard errors for `glmmTMB` models. The concerns are serious enough that I am pushing a release that raises an error when trying to compute standard errors for these models.

Unfortunately, this breaks your vignette. Apologies. This PR should solve the issue.

See the last couple posts in this thread and the link posted at the very bottom for details: https://github.com/vincentarelbundock/marginaleffects/issues/810