### PR TITLE
Adding support mvbind

### DIFF
--- a/R/modeling.R
+++ b/R/modeling.R
@@ -569,12 +569,25 @@ ordbetareg <- function(formula=NULL,
 
 
     class(out_obj) <- c(class(out_obj),"ordbetareg")
+    
+    if(length(dv)==1) {
 
-    out_obj$upper_bound <- attr(data[[dv_pos]],'upper_bound')
-    out_obj$lower_bound <- attr(data[[dv_pos]],'lower_bound')
+      out_obj$upper_bound <- attr(data[[dv_pos]],'upper_bound')
+      out_obj$lower_bound <- attr(data[[dv_pos]],'lower_bound')
 
+    } else {
 
+      # multivariate adjustment necessary
+      
+      out_obj$upper_bound <- lapply(dv_pos, function(c) {
+        return(attr(data[[c]], 'upper_bound'))
+      })
 
+      out_obj$lower_bound <- lapply(dv_pos, function(c) {
+        return(attr(data[[c]], 'lower_bound'))
+      })
+
+    }
 
     return(out_obj)
 


### PR DESCRIPTION
Note the current proposed change has the potential to add unintended consequences with helper packages. For instance, returning a list as lower_bound & upper_bound breaks the current implementation of pp_check_ordbeta.

I'm proposing the change in its current form to solicit feedback. An easier "simple" solution would be to return [0,1] or the bounds of the first response variable in the multivariate case and print a warning.